### PR TITLE
Support locales with up to 5 characters

### DIFF
--- a/lib/traco/class_methods.rb
+++ b/lib/traco/class_methods.rb
@@ -1,7 +1,7 @@
 module Traco
   module ClassMethods
     def locales_for_attribute(attribute)
-      re = /\A#{attribute}_([a-z]{2})\z/
+      re = /\A#{attribute}_([a-zA-Z\-]{2,5})\z/
 
       column_names.
         grep(re) { $1.to_sym }.
@@ -18,7 +18,7 @@ module Traco
 
     def human_attribute_name(attribute, options = {})
       default = super(attribute, options.merge(:default => ""))
-      if default.blank? && attribute.to_s.match(/\A(\w+)_([a-z]{2})\z/)
+      if default.blank? && attribute.to_s.match(/\A(\w+)_([a-zA-Z\-]{2,5})\z/)
         column, locale = $1, $2.to_sym
         if translates?(column)
           return "#{super(column, options)} (#{locale_name(locale)})"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,8 @@ ActiveRecord::Base.establish_connection :adapter => "sqlite3", :database => ":me
 silence_stream(STDOUT) do
   ActiveRecord::Schema.define(:version => 0) do
     create_table :posts, :force => true do |t|
-      t.string :title_sv, :title_en, :title_fi
-      t.string :body_sv, :body_en, :body_fi
+      t.string :title_sv, :title_en, :title_fi, 'title_pt-BR'
+      t.string :body_sv, :body_en, :body_fi, 'body_pt-BR'
     end
   end
 end

--- a/spec/traco_spec.rb
+++ b/spec/traco_spec.rb
@@ -46,7 +46,7 @@ describe Post, ".locales_for_attribute" do
   it "lists the locales, default first and then alphabetically" do
     I18n.default_locale = :fi
     Post.locales_for_attribute(:title).should == [
-      :fi, :en, :sv
+      :fi, :en, :"pt-BR", :sv, 
     ]
   end
 end
@@ -59,15 +59,15 @@ describe Post, ".locale_columns" do
 
   it "lists the columns-with-locale for that attribute, default locale first and then alphabetically" do
     Post.locale_columns(:title).should == [
-      :title_fi, :title_en, :title_sv
+      :title_fi, :title_en, :"title_pt-BR", :title_sv
     ]
   end
 
   it "supports multiple attributes" do
     Post.translates :body
     Post.locale_columns(:body, :title).should == [
-      :body_fi, :body_en, :body_sv,
-      :title_fi, :title_en, :title_sv
+      :body_fi, :body_en, :"body_pt-BR", :body_sv,
+      :title_fi, :title_en, :"title_pt-BR", :title_sv
     ]
   end
 end


### PR DESCRIPTION
Some locales have uppercase letters and hyphen. I changed the regex to support those locales.

Example: https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/pt-BR.yml
