### PR TITLE
Translated attributes should reflect I18n.locale change

### DIFF
--- a/lib/traco/localized_reader.rb
+++ b/lib/traco/localized_reader.rb
@@ -18,7 +18,7 @@ module Traco
     private
 
     def locales_to_try
-      @locales_to_try ||= locale_chain & locales_for_attribute
+      locale_chain & locales_for_attribute
     end
 
     def locale_chain

--- a/spec/traco_spec.rb
+++ b/spec/traco_spec.rb
@@ -128,6 +128,14 @@ describe Post, "#title" do
     post.title.should == "title"
     post.body.should == "body"
   end
+  
+  it "reflects locale change" do
+    post.title.should == "Hej"
+    I18n.locale = :en
+    post.title.should == "Halloa"
+    I18n.locale = :sv
+    post.title.should == "Hej"
+  end
 
   context "with :fallback => false" do
     let(:post) {


### PR DESCRIPTION
When accessing localized attribute it should always return value according to current `I18n.locale` settings.

I should be able to write:

```
I18n.locale = :en
post.title #post.title_en

I18n.locale = :fr
post.title #post.title_fr
```

`locales_to_try` in `LocalizedReader` is cached, so code above don't work. I've removed caching.
