### PR TITLE
Update spec syntax for RSpec 3

### DIFF
--- a/spec/traco_spec.rb
+++ b/spec/traco_spec.rb
@@ -5,28 +5,28 @@ require "traco"
 
 describe ActiveRecord::Base, ".translates" do
   it "is available" do
-    Post.should respond_to :translates
+    expect(Post).to respond_to :translates
   end
 
   it "adds functionality" do
-    Post.new.should_not respond_to :title
+    expect(Post.new).not_to respond_to :title
     Post.translates :title
-    Post.new.should respond_to :title
+    expect(Post.new).to respond_to :title
   end
 
   it "can be run more than once" do
-    Post.new.should_not respond_to :title, :body
+    expect(Post.new).not_to respond_to :title, :body
     Post.translates :title
     Post.translates :body
-    Post.new.should respond_to :title, :body
+    expect(Post.new).to respond_to :title, :body
   end
 
   it "inherits columns from the superclass" do
     Post.translates :title
     SubPost.translates :body
-    SubPost.new.should respond_to :title, :body
-    Post.new.should respond_to :title
-    Post.new.should_not respond_to :body
+    expect(SubPost.new).to respond_to :title, :body
+    expect(Post.new).to respond_to :title
+    expect(Post.new).not_to respond_to :body
   end
 end
 
@@ -36,7 +36,7 @@ describe Post, ".translatable_attributes" do
   end
 
   it "lists the translatable attributes" do
-    Post.translatable_attributes.should == [ :title ]
+    expect(Post.translatable_attributes).to match_array [ :title ]
   end
 end
 
@@ -47,7 +47,7 @@ describe Post, ".locales_for_attribute" do
 
   it "lists the locales, default first and then alphabetically" do
     I18n.default_locale = :"pt-BR"
-    Post.locales_for_attribute(:title).should == [
+    expect(Post.locales_for_attribute(:title)).to match_array [
       :pt_br, :en, :sv
     ]
   end
@@ -60,14 +60,14 @@ describe Post, ".locale_columns" do
   end
 
   it "lists the columns-with-locale for that attribute, default locale first and then alphabetically" do
-    Post.locale_columns(:title).should == [
+    expect(Post.locale_columns(:title)).to match_array [
       :title_pt_br, :title_en, :title_sv
     ]
   end
 
   it "supports multiple attributes" do
     Post.translates :body
-    Post.locale_columns(:body, :title).should == [
+    expect(Post.locale_columns(:body, :title)).to match_array [
       :body_pt_br, :body_en, :body_sv,
       :title_pt_br, :title_en, :title_sv
     ]
@@ -81,7 +81,7 @@ describe Post, ".current_locale_column" do
 
   it "returns the column name for the current locale" do
     I18n.locale = :sv
-    Post.current_locale_column(:title).should == :title_sv
+    expect(Post.current_locale_column(:title)).to eq :title_sv
   end
 end
 
@@ -97,42 +97,42 @@ describe Post, "#title" do
   end
 
   it "gives the title in the current locale" do
-    post.title.should == "Hej"
+    expect(post.title).to eq "Hej"
   end
 
   it "handles dashed locales" do
     I18n.locale = :"pt-BR"
-    post.title_pt_br.should == "Olá"
-    post.title.should == "Olá"
+    expect(post.title_pt_br).to eq "Olá"
+    expect(post.title).to eq "Olá"
   end
 
   it "falls back to the default locale if locale has no column" do
     I18n.locale = :ru
-    post.title.should == "Halloa"
+    expect(post.title).to eq "Halloa"
   end
 
   it "falls back to the default locale if blank" do
     post.title_sv = " "
-    post.title.should == "Halloa"
+    expect(post.title).to eq "Halloa"
   end
 
   it "does not fall back to any other locale if default locale is blank" do
     post.title_sv = " "
     post.title_en = ""
-    post.title.should be_nil
+    expect(post.title).to be_nil
   end
 
   it "does not fall back if called with fallback: false" do
     I18n.locale = :sv
     post.title_sv = ""
-    post.title(fallback: false).should be_nil
+    expect(post.title(fallback: false)).to be_nil
   end
 
   it "returns nil if all are blank" do
     post.title_sv = " "
     post.title_en = ""
     post.title_pt_br = nil
-    post.title.should be_nil
+    expect(post.title).to be_nil
   end
 
   it "is overridable" do
@@ -142,7 +142,7 @@ describe Post, "#title" do
       end
     end
 
-    post.title.should == "jeH"
+    expect(post.title).to eq "jeH"
   end
 
   # Had a regression.
@@ -150,16 +150,16 @@ describe Post, "#title" do
     Post.translates :title, :body
     post.title_sv = "title"
     post.body_sv = "body"
-    post.title.should == "title"
-    post.body.should == "body"
+    expect(post.title).to eq "title"
+    expect(post.body).to eq "body"
   end
 
   it "reflects locale change" do
-    post.title.should == "Hej"
+    expect(post.title).to eq "Hej"
     I18n.locale = :en
-    post.title.should == "Halloa"
+    expect(post.title).to eq "Halloa"
     I18n.locale = :sv
-    post.title.should == "Hej"
+    expect(post.title).to eq "Hej"
   end
 
   context "when the translation was defined with fallback: false" do
@@ -174,18 +174,18 @@ describe Post, "#title" do
 
     it "does not fall back to the default locale if locale has no column" do
       I18n.locale = :ru
-      post.title.should be_nil
+      expect(post.title).to be_nil
     end
 
     it "does not fall back to the default locale if blank" do
       I18n.locale = :sv
       post.title_sv = " "
-      post.title.should be_nil
+      expect(post.title).to be_nil
     end
 
     it "still falls back if called with fallback: :default" do
       I18n.locale = :ru
-      post.title(fallback: :default).should == "Halloa"
+      expect(post.title(fallback: :default)).to eq "Halloa"
     end
   end
 
@@ -198,12 +198,12 @@ describe Post, "#title" do
 
     it "falls back to any locale, not just the default" do
       post = Post.new(title_en: "", title_pt_br: "", title_sv: "Hej")
-      post.title.should == "Hej"
+      expect(post.title).to eq "Hej"
     end
 
     it "prefers the default locale" do
       post = Post.new(title_en: "Hello", title_pt_br: "", title_sv: "Hej")
-      post.title.should == "Hello"
+      expect(post.title).to eq "Hello"
     end
   end
 end
@@ -218,20 +218,20 @@ describe Post, "#title=" do
   it "assigns in the current locale" do
     I18n.locale = :sv
     post.title = "Hej"
-    post.title_sv.should == "Hej"
+    expect(post.title_sv).to eq "Hej"
   end
 
   it "handles dashed locales" do
     I18n.locale = :"pt-BR"
     post.title = "Olá"
-    post.title_pt_br.should == "Olá"
+    expect(post.title_pt_br).to eq "Olá"
   end
 
   it "raises if locale has no column" do
     I18n.locale = :ru
-    lambda {
+    expect {
       post.title = "Privet"
-    }.should raise_error(NoMethodError, /title_ru/)
+    }.to raise_error(NoMethodError, /title_ru/)
   end
 end
 
@@ -242,32 +242,32 @@ describe Post, ".human_attribute_name" do
   end
 
   it "uses explicit translations if present" do
-    Post.human_attribute_name(:title_sv).should == "Svensk titel"
+    expect(Post.human_attribute_name(:title_sv)).to eq "Svensk titel"
   end
 
   it "appends translated language name if present" do
-    Post.human_attribute_name(:title_en).should == "Titel (engelska)"
+    expect(Post.human_attribute_name(:title_en)).to eq "Titel (engelska)"
   end
 
   it "appends an abbreviation when language name is not translated" do
-    Post.human_attribute_name(:title_pt_br).should == "Titel (PT-BR)"
+    expect(Post.human_attribute_name(:title_pt_br)).to eq "Titel (PT-BR)"
   end
 
   it "passes through the default behavior for untranslated attributes" do
-    Post.human_attribute_name(:title).should == "Titel"
+    expect(Post.human_attribute_name(:title)).to eq "Titel"
   end
 
   it "passes through untranslated attributes even if the name suggests it's translated" do
-    Post.human_attribute_name(:body_sv).should == "Body sv"
+    expect(Post.human_attribute_name(:body_sv)).to eq "Body sv"
   end
 
   # ActiveModel::Errors#full_messages passes in an ugly default.
 
   it "does not honor passed-in defaults for locale columns" do
-    Post.human_attribute_name(:title_en, default: "Title en").should == "Titel (engelska)"
+    expect(Post.human_attribute_name(:title_en, default: "Title en")).to eq "Titel (engelska)"
   end
 
   it "passes through defaults" do
-    Post.human_attribute_name(:body_sv, default: "Boday").should == "Boday"
+    expect(Post.human_attribute_name(:body_sv, default: "Boday")).to eq "Boday"
   end
 end


### PR DESCRIPTION
Just adds extra flavour to your otherwise perfect code style :) Checked with rspec 3.0.0.beta2 -only `treat_symbols_as_metadata_keys_with_true_values` need to be removed when the day comes for rspec 3 stable release.
