### PR TITLE
! Fix `.current_locale_column` match current column naming convention

### DIFF
--- a/lib/traco/class_methods.rb
+++ b/lib/traco/class_methods.rb
@@ -19,7 +19,7 @@ module Traco
     end
 
     def current_locale_column(attribute)
-      :"#{attribute}_#{I18n.locale}"
+      :"#{attribute}_#{I18n.locale.to_s.downcase.sub("-", "_")}"
     end
 
     def human_attribute_name(attribute, options = {})

--- a/spec/traco_spec.rb
+++ b/spec/traco_spec.rb
@@ -83,6 +83,11 @@ describe Post, ".current_locale_column" do
     I18n.locale = :sv
     expect(Post.current_locale_column(:title)).to eq :title_sv
   end
+
+  it "returns the column name with right format for the current locale with region identifier" do
+    I18n.locale = :"pt-BR"
+    expect(Post.current_locale_column(:title)).to eq :title_pt_br
+  end
 end
 
 describe Post, "#title" do


### PR DESCRIPTION
Fix for #26
