### PR TITLE
Do not call ActiveRecord methods while including the module.

### DIFF
--- a/lib/traco/attributes.rb
+++ b/lib/traco/attributes.rb
@@ -14,8 +14,6 @@ module Traco
       self.class.ensure_translatable_attributes(base)
       base.translatable_attributes |= @attributes
 
-      self.class.warm_up_activerecord_methods(base)
-
       base.extend ClassMethods
     end
 
@@ -57,15 +55,6 @@ module Traco
 
       base.class_attribute :translatable_attributes
       base.translatable_attributes = []
-    end
-
-    # Force AR to create methods `title_en` etc, which are lazily evaluated,
-    # otherwise we can't safely check `.instance_methods`.
-    def self.warm_up_activerecord_methods(base)
-      random_attribute = base.translatable_attributes.first
-
-      instance = base.new
-      instance.send(Traco.column(random_attribute, I18n.default_locale))
     end
   end
 end

--- a/lib/traco/class_methods.rb
+++ b/lib/traco/class_methods.rb
@@ -58,11 +58,15 @@ module Traco
       per_attribute_cache = per_locale_cache[attribute] ||= {}
 
       per_attribute_cache[fallback] ||= begin
+        # AR methods are lazily evaluated, so we should use `respond_to?` on this
+        # class instance, rather then `instance_methods.include?(:title_en)`
+        instance = new
+
         locales_to_try = Traco.locale_with_fallbacks(I18n.locale, fallback)
 
         locales_to_try.each_with_object({}) do |locale, columns|
           column = Traco.column(attribute, locale)
-          columns[locale] = column if instance_methods.include?(column)
+          columns[locale] = column if instance.respond_to?(column)
         end
       end
     end


### PR DESCRIPTION
#30

This raised an exception in DB rake tasks when DB had not exist yet,
while AR needed a schema.

@henrik, don't know how to test this
