### PR TITLE
Add `fallback: :i18n` to use the fallbacks from `I18n.fallbacks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Feature: Add `fallback: :i18n` to use the fallbacks from `I18n.fallbacks`.
+
 ## 5.0.0
 
 * Change `locale_columns` and `locales_for_attribute` to sort current locale first, then default locale (previously, it was default locale first). This makes more sense for our own apps, and hopefully other apps as well.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ You can specify e.g. `translates :title, fallback: :any` to fall back first to t
 
 You can specify e.g. `translates :title, fallback: [:sv]` to explicitly declare fallbacks as an array of any length.
 
+You can specify e.g. `translates :title, fallback: :i18n` to use the fallbacks from `I18n.fallbacks`.
+
 You can override the default fallback strategy with a parameter passed to the reader: `post.title(fallback: :any)`.
 
 If you need to declare the default locale fallback, do `post.title(fallback: :default)`.

--- a/lib/traco/locale_fallbacks.rb
+++ b/lib/traco/locale_fallbacks.rb
@@ -7,6 +7,7 @@ module Traco
       ANY_FALLBACK = :any,
       NO_FALLBACK = false,
       DEFAULT_FIRST_FALLBACK = :default_first,
+      I18N_FALLBACK = :i18n,
     ]
 
     attr_reader :fallback_option
@@ -26,6 +27,7 @@ module Traco
       when ANY_FALLBACK           then [ current_locale, @default_locale, *@available_locales ].uniq
       when NO_FALLBACK            then [ current_locale ]
       when DEFAULT_FIRST_FALLBACK then [ @default_locale, *@available_locales ].uniq
+      when I18N_FALLBACK          then I18n.fallbacks[current_locale]
       when Array                  then [ current_locale, *fallback_option ]
       else                        raise "Unknown fallback."  # Should never get here.
       end

--- a/spec/locale_fallbacks_spec.rb
+++ b/spec/locale_fallbacks_spec.rb
@@ -51,5 +51,20 @@ describe Traco::LocaleFallbacks do
         expect(subject[:sv]).to eq [ :uk, :de, :en, :sv ]
       end
     end
+
+    context "with the ':i18n' option" do
+      it "returns what is configured as a I18n fallback" do
+        I18n.fallbacks = I18n::Locale::Fallbacks.new(
+          en: [ :en, :uk, :de, :sv ],
+          uk: [ :uk, :en, :de, :sv ],
+          de: [ :de, :uk, :en, :sv ],
+          sv: [ :sv, :en, :uk, :de ],
+        )
+
+        subject = Traco::LocaleFallbacks.new(:i18n)
+        expect(subject[:sv]).to eq [ :sv, :en, :uk, :de ]
+        expect(subject[:de]).to eq [ :de, :uk, :en, :sv ]
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,5 @@ RSpec.configure do |config|
 end
 
 I18n.enforce_available_locales = false
+
+I18n::Backend::Simple.include(I18n::Backend::Fallbacks)


### PR DESCRIPTION
Adds a `:i18n` value to the `fallbacks:` that uses `I18n.fallbacks`. This allows an application to decide which locale falls back to which.

The current options allow only a fixed list of locales that do not depend on the current locale. E.g. it makes sense that the first fallback for `:en-GB` is `:en`, but this might not be the case for `:fr-CA`.