### PR TITLE
return all locale columns when no params are supplied

### DIFF
--- a/lib/traco/class_methods.rb
+++ b/lib/traco/class_methods.rb
@@ -5,9 +5,10 @@ module Traco
     end
 
     def locale_columns(*attributes)
-      attributes.flat_map { |attribute|
+      attributes = attributes.presence || translatable_attributes
+      attributes.flat_map do |attribute|
         _locale_columns_for_attribute(attribute, fallback: LocaleFallbacks::ANY_FALLBACK)
-      }
+      end
     end
 
     # Consider this method internal.

--- a/lib/traco/class_methods.rb
+++ b/lib/traco/class_methods.rb
@@ -6,9 +6,9 @@ module Traco
 
     def locale_columns(*attributes)
       attributes = attributes.presence || translatable_attributes
-      attributes.flat_map do |attribute|
+      attributes.flat_map { |attribute|
         _locale_columns_for_attribute(attribute, fallback: LocaleFallbacks::ANY_FALLBACK)
-      end
+      }
     end
 
     # Consider this method internal.

--- a/spec/traco_spec.rb
+++ b/spec/traco_spec.rb
@@ -113,12 +113,18 @@ RSpec.describe Post, ".locale_columns" do
     expect(Post.locale_columns(:title)).not_to include(:title_ru)
   end
 
-it "supports multiple attributes" do
-  Post.translates :body
+  it "supports multiple attributes" do
+    Post.translates :body
 
     expect(Post.locale_columns(:body, :title)).to eq [
       :body_en, :body_pt_br, :body_de, :body_sv,
       :title_en, :title_pt_br, :title_de, :title_sv,
+    ]
+  end
+
+  it "returns the columns of all translated attributes if no params are supplied" do
+    expect(Post.locale_columns).to eq [
+      :title_en, :title_pt_br, :title_de, :title_sv
     ]
   end
 end


### PR DESCRIPTION
Is there any reason we can't return all locale columns when no params are passed to `.locale_columns`?